### PR TITLE
Rename sslcert to sslcertificate

### DIFF
--- a/share/modules
+++ b/share/modules
@@ -52,7 +52,7 @@ puppet-selinux
 puppet-smokeping
 puppet-splunk
 puppet-squid
-puppet-sslcert
+puppet-sslcertificate
 puppet-staging
 puppet-stash
 puppet-tea


### PR DESCRIPTION
github repo name was wrong.  Correct module name has always been
`sslcertificate`
https://forge.puppet.com/opentable/sslcertificate/2.1.0/readme
https://forge.puppet.com/puppet/sslcertificate