### PR TITLE
Add `puppet-python`

### DIFF
--- a/share/modules
+++ b/share/modules
@@ -68,6 +68,7 @@ puppet-prometheus_reporter
 puppet-proxysql
 puppet-puppetboard
 puppet-puppetserver
+puppet-python
 puppet-r10k
 puppet-rabbitmq
 puppet-report_hipchat


### PR DESCRIPTION
`puppet-python` has been moved under https://github.com/voxpupuli/puppet-python.